### PR TITLE
New type 'jsonObject' for simple fields

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>com.rest4j</groupId>
     <artifactId>rest4j-core</artifactId>
-	<version>1.2-ecwid.12</version>
+	<version>1.2-ecwid-13</version>
 	<url>https://code.google.com/p/rest4j/</url>
 	<scm>
 		<connection>

--- a/core/src/main/java/com/rest4j/Marshaller.java
+++ b/core/src/main/java/com/rest4j/Marshaller.java
@@ -111,4 +111,10 @@ public interface Marshaller {
 	 * can be applied to JSON fields.
 	 */
 	DateApiType getDateType();
+
+	/**
+	 * Returns an API type representing numbers (type='jsonObject' in API XML). This type
+	 * can be applied to JSON fields.
+	 */
+	JsonObjectApiType getJsonObjectType();
 }

--- a/core/src/main/java/com/rest4j/impl/JsonObjectApiTypeImpl.java
+++ b/core/src/main/java/com/rest4j/impl/JsonObjectApiTypeImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rest4j.impl;
+
+import com.rest4j.ApiException;
+import com.rest4j.Marshaller;
+import com.rest4j.json.JSONObject;
+import com.rest4j.type.JsonObjectApiType;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Type;
+
+public class JsonObjectApiTypeImpl extends SimpleApiTypeImpl implements JsonObjectApiType {
+    JsonObjectApiTypeImpl(Marshaller marshaller) {
+        super(marshaller);
+    }
+
+    @Override
+    public boolean equals(Object val1, Object val2) {
+        if (val1 != null) {
+            return val1.equals(val2);
+        } else {
+            return val2 == null;
+        }
+    }
+
+    @Override
+    public boolean check(Type javaType) {
+        return javaType == JSONObject.class;
+    }
+
+    @Override
+    public Object cast(@Nullable Object value, Type javaType) throws NullPointerException {
+        assert value == null || value instanceof JSONObject : value.getClass();
+        assert javaType == JSONObject.class : javaType;
+        return value;
+    }
+
+    @Override
+    public String getJavaName() {
+        return JSONObject.class.getName();
+    }
+
+    @Override
+    Object unmarshal(Object val) throws ApiException {
+        if (val == JSONObject.NULL) {
+            return null;
+        } else if (val instanceof JSONObject) {
+            return val;
+        } else {
+            throw new ApiException("{value} should be an object");
+        }
+    }
+
+    @Override
+    Object marshal(Object val) throws ApiException {
+        if (val == null) {
+            return JSONObject.NULL;
+        } else if (val instanceof JSONObject) {
+            return val;
+        } else {
+            throw new ApiException("Expected " + getJavaName() + ", "+val.getClass()+" given").setHttpStatus(500);
+        }
+    }
+}

--- a/core/src/main/java/com/rest4j/impl/MarshallerImpl.java
+++ b/core/src/main/java/com/rest4j/impl/MarshallerImpl.java
@@ -183,6 +183,11 @@ public class MarshallerImpl implements Marshaller {
 	}
 
 	@Override
+	public JsonObjectApiType getJsonObjectType() {
+		return new JsonObjectApiTypeImpl(this);
+	}
+
+	@Override
 	public Object marshal(ApiType apiType, Object value) throws ApiException {
 		if (apiType instanceof ConcreteClassMapping) apiType = ((ConcreteClassMapping)apiType).objectApiType;
 		return ((ApiTypeImpl)apiType).marshal(value);
@@ -214,6 +219,9 @@ public class MarshallerImpl implements Marshaller {
 				break;
 			case DATE:
 				apiType = getDateType();
+				break;
+			case JSON_OBJECT:
+				apiType = getJsonObjectType();
 				break;
 			default:
 				throw new AssertionError();

--- a/core/src/main/java/com/rest4j/impl/model/FieldType.java
+++ b/core/src/main/java/com/rest4j/impl/model/FieldType.java
@@ -41,7 +41,9 @@ public enum FieldType {
     @XmlEnumValue("boolean")
     BOOLEAN("boolean"),
     @XmlEnumValue("date")
-    DATE("date");
+    DATE("date"),
+    @XmlEnumValue("jsonObject")
+    JSON_OBJECT("jsonObject");
     private final String value;
 
     FieldType(String v) {

--- a/core/src/main/java/com/rest4j/type/JsonObjectApiType.java
+++ b/core/src/main/java/com/rest4j/type/JsonObjectApiType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rest4j.type;
+
+/**
+ * The API type corresponding to type='jsonObject' in API XML. You can get an instance
+ * using {@link com.rest4j.Marshaller} methods.
+ */
+public interface JsonObjectApiType extends SimpleApiType {
+}

--- a/core/src/main/resources/com/rest4j/api.xsd
+++ b/core/src/main/resources/com/rest4j/api.xsd
@@ -430,14 +430,15 @@ through the com.rest4j.type.Field.getExtra() method.
 				</xsd:sequence>
 				<xsd:attribute name="type" type="FieldType" use="optional" default="string">
 					<xsd:annotation><xsd:documentation>
-A type of the field, one of 'number', 'string', 'boolean', 'date'. These types are mapped to
-java types in the following way:
+A type of the field, one of 'number', 'string', 'boolean', 'date', 'jsonObject'.
+These types are mapped to java types in the following way:
 
 || *API type*|| *Property type*||
 || number    || java.lang.Number, or double/int/long plus boxed variants.||
 || string    || java.lang.String or an enum containing `parameter/values/value` constants||
 || boolean   || boolean or java.lang.Boolean||
-|| date      || java.lang.Date or java.sql.Date||
+|| date      || java.util.Date or java.sql.Date||
+|| jsonObject|| com.rest4j.json.JSONObject
 					</xsd:documentation></xsd:annotation>
 				</xsd:attribute>
 				<xsd:attribute name="value" type="xsd:string">
@@ -605,6 +606,7 @@ set to the exception class name.
 			<xsd:enumeration value="string" />
 			<xsd:enumeration value="boolean" />
 			<xsd:enumeration value="date" />
+			<xsd:enumeration value="jsonObject" />
 		</xsd:restriction>
 	</xsd:simpleType>
 

--- a/core/src/test/java/com/rest4j/impl/petapi/Pet.java
+++ b/core/src/test/java/com/rest4j/impl/petapi/Pet.java
@@ -19,6 +19,7 @@ package com.rest4j.impl.petapi;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Joseph Kapizza <joseph@rest4j.com>
@@ -34,6 +35,7 @@ public class Pet {
 	List<Integer> ate = new ArrayList<Integer>();
 	boolean writeonly;
 	char middlename = 1;
+	Map<String, String> extraData;
 
 	public boolean isWriteonly() {
 		return writeonly;
@@ -113,5 +115,13 @@ public class Pet {
 
 	public void setMiddlename(char middlename) {
 		this.middlename = middlename;
+	}
+
+	public Map<String, String> getExtraData() {
+		return extraData;
+	}
+
+	public void setExtraData(Map<String, String> extraData) {
+		this.extraData = extraData;
 	}
 }

--- a/core/src/test/java/com/rest4j/impl/petapi/PetMapping.java
+++ b/core/src/test/java/com/rest4j/impl/petapi/PetMapping.java
@@ -17,8 +17,12 @@
 
 package com.rest4j.impl.petapi;
 
+import com.rest4j.json.JSONObject;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Joseph Kapizza <joseph@rest4j.com>
@@ -60,6 +64,25 @@ public class PetMapping {
 					pet.getAte().add(rel.getPetId());
 					break;
 			}
+		}
+	}
+
+	public JSONObject extraData(Pet pet) {
+		if (pet.extraData != null) {
+			return new JSONObject(pet.extraData);
+		} else {
+			return null;
+		}
+	}
+
+	public void extraData(Pet pet, final JSONObject extraData) {
+		if (extraData != null) {
+			pet.extraData = new HashMap<String, String>();
+			for (String key: (Set<String>) extraData.keySet()) {
+				pet.extraData.put(key, (String) extraData.get(key));
+			}
+		} else {
+			pet.extraData = null;
 		}
 	}
 }

--- a/core/src/test/resources/com/rest4j/impl/petapi.xml
+++ b/core/src/test/resources/com/rest4j/impl/petapi.xml
@@ -37,6 +37,7 @@
 				</values>
 			</simple>
 			<simple name="writeonly" type="boolean" access="writeonly" nullable="true"/>
+			<simple name="extraData" type="jsonObject" mapping-method="extraData" nullable="true"/>
 			<complex name="relations" collection="array" type="PetRelation" mapping-method="petRelations" nullable="false" default="empty"/>
 		</fields>
 	</model>


### PR DESCRIPTION
В rest4j есть ограничение - невозможно представить структуру вида map of map.
Поэтому мы добавляем новый тип для простых полей: jsonObject. Этот тип позволяет представить произвольный JSON-объект в виде com.rest4j.json.JSONObject. 
При практическом использовании полей такого типа, следует использовать конвертеры или мапперы.