### PR TITLE
Fix concurrent mapping

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
 
 
 	<artifactId>rest4j-core</artifactId>
-	<version>1.2-ecwid-25</version>
+	<version>1.2-ecwid-26</version>
 	<url>https://code.google.com/p/rest4j/</url>
 	<scm>
 		<connection>
@@ -59,7 +59,7 @@
 	<parent>
 		<artifactId>rest4j</artifactId>
 		<groupId>com.rest4j</groupId>
-		<version>1.2-ecwid-25</version>
+		<version>1.2-ecwid-26</version>
 	</parent>
 	<build>
 		<plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -154,7 +154,7 @@
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>3.0.1</version>
+			<version>4.0.2</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/core/src/test/java/com/rest4j/impl/APIImplTest.java
+++ b/core/src/test/java/com/rest4j/impl/APIImplTest.java
@@ -582,7 +582,6 @@ public class APIImplTest {
 		assertEquals("{\"id\":0}", getBody(response));
 	}
 
-	@Disabled
 	@Test public void testServe_jsonp_plain_text() throws Exception {
 		iniJsonpApi();
 		ApiRequest request = mockRequest("GET", "/api/v2/pet/text");
@@ -592,7 +591,6 @@ public class APIImplTest {
 		assertEquals("callback_func(\"Just a pet\\n\")", getBody(response));
 	}
 
-	@Disabled
 	@Test public void testServe_jsonp_binary() throws Exception {
 		iniJsonpApi();
 		ApiRequest request = mockRequest("GET", "/api/v2/pet/binary");

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>rest4j</artifactId>
 		<groupId>com.rest4j</groupId>
-		<version>1.2-ecwid-25</version>
+		<version>1.2-ecwid-26</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.rest4j</groupId>
     <artifactId>rest4j</artifactId>
 	<packaging>pom</packaging>
-	<version>1.2-ecwid-25</version>
+	<version>1.2-ecwid-26</version>
 	<url>https://code.google.com/p/rest4j/</url>
 	<scm>
 		<connection>


### PR DESCRIPTION
Fix concurrent exception
```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
	at com.rest4j.impl.ObjectApiTypeImpl.getMapping(ObjectApiTypeImpl.java:155)
	at com.rest4j.impl.ObjectApiTypeImpl.marshal(ObjectApiTypeImpl.java:118)
	at com.rest4j.impl.MarshallerImpl.marshal(MarshallerImpl.java:201)
	at com.rest4j.impl.ArrayApiTypeImpl.marshal(ArrayApiTypeImpl.java:164)
	at com.rest4j.impl.MarshallerImpl.marshal(MarshallerImpl.java:201)
	at com.rest4j.impl.FieldMapping.marshal(FieldMapping.java:127)
	at com.rest4j.impl.ConcreteClassMapping.marshal(ConcreteClassMapping.java:96)
	at com.rest4j.impl.ObjectApiTypeImpl.marshal(ObjectApiTypeImpl.java:118)
	at com.rest4j.impl.MarshallerImpl.marshal(MarshallerImpl.java:201)
	at com.rest4j.impl.FieldMapping.marshal(FieldMapping.java:127)
	at com.rest4j.impl.ConcreteClassMapping.marshal(ConcreteClassMapping.java:96)
	at com.rest4j.impl.ObjectApiTypeImpl.marshal(ObjectApiTypeImpl.java:118)
	at com.rest4j.impl.MarshallerImpl.marshal(MarshallerImpl.java:201)
```